### PR TITLE
Checkout khmer tag v2.1.1 to preserve compatilbility with python2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:15.10
 RUN apt-get update && apt-get install -y python-dev zlib1g git python-setuptools g++ make    
 RUN cd /home
-RUN git clone https://github.com/dib-lab/sourmash.git &&     cd sourmash &&     python setup.py install 
+RUN git clone https://github.com/dib-lab/sourmash.git -b v2.1.1 &&     cd sourmash &&     python setup.py install 


### PR DESCRIPTION
This dockerfile does not work after khmer version 924f19d on 2017-05-31.
Checking out the v2.1.1 tag allows this python2.7 dockerfile to continue working.