### PR TITLE
Checkout khmer tag v2.1.1 to preserve compatilbility with python2.7

### DIFF
--- a/make_khmer/Dockerfile
+++ b/make_khmer/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:15.10
 RUN apt-get update && apt-get install -y git     python2.7-dev     python-pip     gcc     g++
 RUN cd /home
-RUN git clone https://github.com/dib-lab/khmer.git &&     cd khmer &&     python setup.py install 
+RUN git clone https://github.com/dib-lab/khmer.git &&     cd khmer &&     git checkout v2.1.1    && python setup.py install 

--- a/make_khmer/README.md
+++ b/make_khmer/README.md
@@ -21,6 +21,7 @@
 	RUN cd /home
 	RUN git clone https://github.com/dib-lab/khmer.git && \
 		cd khmer && \
+		git checkout v2.1.1 && \
 		python setup.py install 
 	EOF
 	


### PR DESCRIPTION
The make_khmer Dockerfile does not work after khmer version 924f19d on 2017-05-31.

Checking out the v2.1.1 tag allows this python2.7 dockerfile to continue working.
